### PR TITLE
Fix tests when using latest legacy mongo driver

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -75,6 +75,24 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>de.flapdoodle.embed</groupId>
+                    <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo.download-and-extract</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.rest</groupId>

--- a/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
-import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.redhat.lightblue.config.CrudConfiguration;
 import com.redhat.lightblue.config.MetadataConfiguration;
 import com.redhat.lightblue.metadata.EntityMetadata;
@@ -129,7 +129,7 @@ public class ITCaseCrudResourceTest {
 
     private static MongodExecutable mongodExe;
     private static MongodProcess mongod;
-    private static Mongo mongo;
+    private static MongoClient mongo;
     private static DB db;
 
     static {
@@ -166,7 +166,7 @@ public class ITCaseCrudResourceTest {
                 // try again, could be killed breakpoint in IDE
                 mongod = mongodExe.start();
             }
-            mongo = new Mongo(IN_MEM_CONNECTION_URL);
+            mongo = new MongoClient(IN_MEM_CONNECTION_URL);
 
             MongoConfiguration config = new MongoConfiguration();
             // disable ssl for test (enabled by default)

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
         <maven.compiler.verbose>true</maven.compiler.verbose>
 
         <lightblue.core.version>2.17.0</lightblue.core.version>
-        <lightblue.mongo.version>1.34.0</lightblue.mongo.version>
+        <lightblue.mongo.version>1.35.1-SNAPSHOT</lightblue.mongo.version>
         <lightblue.ldap.version>1.11.0</lightblue.ldap.version>
         <lightblue.audithook.version>1.10.0</lightblue.audithook.version>
         <lightblue.notificationhook.version>0.1.3</lightblue.notificationhook.version>


### PR DESCRIPTION
Update to snapshot dep for lightblue.mongo.version
Exclude flapdoodle transitive dep in rest/crud
Explictly declare backlevel flapdoodle dep to resolve compile issues
Switch from `Mongo` to `MongoClient` in crud integration test.